### PR TITLE
Add Medium blog integration

### DIFF
--- a/blog-post.html
+++ b/blog-post.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Post | Sam Rayatnia</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    /* ── Prose styles for Medium article content ── */
+    .prose-content {
+      font-size: 1.0625rem;
+      line-height: 1.85;
+      color: #374151;
+    }
+    .prose-content h1,
+    .prose-content h2,
+    .prose-content h3,
+    .prose-content h4 {
+      font-weight: 700;
+      color: #111827;
+      margin: 2.25rem 0 1rem;
+      line-height: 1.3;
+    }
+    .prose-content h1 { font-size: 2rem; }
+    .prose-content h2 { font-size: 1.5rem; border-bottom: 1px solid #e5e7eb; padding-bottom: 0.5rem; }
+    .prose-content h3 { font-size: 1.25rem; }
+    .prose-content h4 { font-size: 1.1rem; }
+    .prose-content p  { margin: 1.35rem 0; }
+    .prose-content a  {
+      color: #3b82f6;
+      text-decoration: underline;
+      text-underline-offset: 3px;
+    }
+    .prose-content a:hover { color: #2563eb; }
+    .prose-content img {
+      border-radius: 0.875rem;
+      max-width: 100%;
+      height: auto;
+      margin: 2rem auto;
+      display: block;
+      box-shadow: 0 4px 20px rgba(0,0,0,.08);
+    }
+    .prose-content figure { margin: 2rem 0; }
+    .prose-content figcaption {
+      text-align: center;
+      font-size: 0.875rem;
+      color: #6b7280;
+      margin-top: 0.5rem;
+      font-style: italic;
+    }
+    .prose-content pre {
+      background: #0f172a;
+      color: #e2e8f0;
+      border-radius: 0.875rem;
+      padding: 1.5rem 1.75rem;
+      overflow-x: auto;
+      margin: 1.75rem 0;
+      font-size: 0.875rem;
+      line-height: 1.7;
+    }
+    .prose-content code {
+      background: #f1f5f9;
+      color: #1e40af;
+      padding: 0.2em 0.45em;
+      border-radius: 0.3rem;
+      font-size: 0.875em;
+      font-family: ui-monospace, 'SFMono-Regular', Consolas, monospace;
+    }
+    .prose-content pre code {
+      background: transparent;
+      color: inherit;
+      padding: 0;
+      font-size: inherit;
+      border-radius: 0;
+    }
+    .prose-content blockquote {
+      border-left: 4px solid #3b82f6;
+      padding: 0.75rem 1.5rem;
+      margin: 1.75rem 0;
+      color: #4b5563;
+      font-style: italic;
+      background: #eff6ff;
+      border-radius: 0 0.75rem 0.75rem 0;
+    }
+    .prose-content ul,
+    .prose-content ol  { margin: 1.25rem 0; padding-left: 1.75rem; }
+    .prose-content ul  { list-style-type: disc; }
+    .prose-content ol  { list-style-type: decimal; }
+    .prose-content li  { margin: 0.5rem 0; }
+    .prose-content hr  { border: none; border-top: 1px solid #e5e7eb; margin: 2.5rem 0; }
+    .prose-content strong { font-weight: 600; color: #111827; }
+    .prose-content em { font-style: italic; }
+    .prose-content table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.75rem 0;
+      font-size: 0.9375rem;
+    }
+    .prose-content th {
+      background: #f8fafc;
+      font-weight: 600;
+      color: #1e293b;
+      padding: 0.75rem 1rem;
+      border: 1px solid #e2e8f0;
+      text-align: left;
+    }
+    .prose-content td {
+      padding: 0.65rem 1rem;
+      border: 1px solid #e2e8f0;
+      color: #374151;
+    }
+    .prose-content tr:nth-child(even) td { background: #f8fafc; }
+
+    /* Loading skeleton animation */
+    @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:.5} }
+    .skeleton-line { animation: pulse 1.8s ease-in-out infinite; background:#e5e7eb; border-radius:0.5rem; }
+  </style>
+</head>
+
+<body class="bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 min-h-screen flex flex-col">
+
+  <nav class="w-full flex justify-center gap-6 py-6 bg-white/90 backdrop-blur-sm shadow-sm sticky top-0 z-10 border-b border-gray-100">
+    <a href="index.html"      class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Home</a>
+    <a href="profile.html"    class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Profile</a>
+    <a href="experience.html" class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Experience</a>
+    <a href="education.html"  class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Education</a>
+    <a href="skills.html"     class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Skills</a>
+    <a href="blog.html"       class="font-medium text-blue-600 border-b-2 border-blue-500 pb-1">Blog</a>
+  </nav>
+
+  <main class="flex-1 py-12 px-4">
+    <div class="max-w-3xl mx-auto">
+
+      <!-- Back link -->
+      <a href="blog.html"
+         class="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-blue-600 transition-colors mb-8 group">
+        <svg class="w-4 h-4 group-hover:-translate-x-0.5 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+        </svg>
+        Back to all posts
+      </a>
+
+      <!-- Loading skeleton -->
+      <div id="post-loading">
+        <div class="flex gap-2 mb-5">
+          <div class="skeleton-line h-6 w-20 rounded-full"></div>
+          <div class="skeleton-line h-6 w-16 rounded-full"></div>
+        </div>
+        <div class="skeleton-line h-10 w-full mb-3"></div>
+        <div class="skeleton-line h-10 w-4/5 mb-6"></div>
+        <div class="skeleton-line h-4 w-64 mb-10"></div>
+        <div class="space-y-3">
+          <div class="skeleton-line h-4 w-full"></div>
+          <div class="skeleton-line h-4 w-full"></div>
+          <div class="skeleton-line h-4 w-5/6"></div>
+          <div class="skeleton-line h-4 w-full mt-6"></div>
+          <div class="skeleton-line h-4 w-full"></div>
+          <div class="skeleton-line h-4 w-4/5"></div>
+          <div class="skeleton-line h-4 w-full mt-6"></div>
+          <div class="skeleton-line h-4 w-3/4"></div>
+        </div>
+      </div>
+
+      <!-- Error state -->
+      <div id="post-error" class="hidden text-center py-16">
+        <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
+          <svg class="w-8 h-8 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+          </svg>
+        </div>
+        <h3 class="text-xl font-semibold text-gray-700 mb-2">Post not found</h3>
+        <p class="text-gray-500 mb-6">This post could not be loaded. It may have been removed or the link is invalid.</p>
+        <a href="blog.html"
+           class="inline-flex items-center gap-2 px-5 py-2.5 bg-blue-600 text-white rounded-xl font-medium hover:bg-blue-700 transition-colors">
+          Back to blog
+        </a>
+      </div>
+
+      <!-- Post content (populated by blog.js) -->
+      <div id="post-container" class="bg-white rounded-2xl shadow-sm border border-gray-100 p-8 sm:p-12"></div>
+
+    </div>
+  </main>
+
+  <footer class="text-center py-8 text-sm text-gray-400 border-t border-gray-100 bg-white/60">
+    <p>
+      Words by <a href="index.html" class="text-blue-500 hover:text-blue-600">Sam Rayatnia</a>
+      · Originally published on
+      <a href="https://blog.rayatnia.me" target="_blank" rel="noopener noreferrer"
+         class="text-blue-500 hover:text-blue-600">Medium</a>
+    </p>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js" defer></script>
+  <script src="static/js/blog.js" defer></script>
+</body>
+</html>

--- a/blog.html
+++ b/blog.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Blog | Sam Rayatnia</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+
+<body class="bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 min-h-screen flex flex-col">
+
+  <nav class="w-full flex justify-center gap-6 py-6 bg-white/90 backdrop-blur-sm shadow-sm sticky top-0 z-10 border-b border-gray-100">
+    <a href="index.html"      class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Home</a>
+    <a href="profile.html"    class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Profile</a>
+    <a href="experience.html" class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Experience</a>
+    <a href="education.html"  class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Education</a>
+    <a href="skills.html"     class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Skills</a>
+    <a href="blog.html"       class="font-medium text-blue-600 border-b-2 border-blue-500 pb-1">Blog</a>
+  </nav>
+
+  <main class="flex-1 py-12 px-4">
+    <div class="max-w-6xl mx-auto">
+
+      <!-- Page header -->
+      <div class="text-center mb-10">
+        <h1 class="text-4xl font-bold text-gray-900 mb-4">Writing</h1>
+        <p class="text-gray-500 text-lg max-w-xl mx-auto">
+          Thoughts on iOS engineering, software architecture, and the occasional detour into computational neuroscience.
+        </p>
+        <div class="w-24 h-1 bg-gradient-to-r from-blue-500 to-indigo-500 mx-auto rounded-full mt-6"></div>
+      </div>
+
+      <!-- Tag filter -->
+      <div id="tag-bar" class="flex flex-wrap gap-2 justify-center mb-8 min-h-[36px]"></div>
+
+      <!-- Post count -->
+      <p id="post-count" class="text-center text-sm text-gray-400 mb-6"></p>
+
+      <!-- Error state -->
+      <div id="blog-error" class="hidden text-center py-16">
+        <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
+          <svg class="w-8 h-8 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+          </svg>
+        </div>
+        <h3 class="text-xl font-semibold text-gray-700 mb-2">Could not load posts</h3>
+        <p class="text-gray-500 mb-6">There was a problem fetching the blog feed. Please try again later.</p>
+        <a href="https://blog.rayatnia.me" target="_blank" rel="noopener noreferrer"
+           class="inline-flex items-center gap-2 px-5 py-2.5 bg-blue-600 text-white rounded-xl font-medium hover:bg-blue-700 transition-colors">
+          Read on Medium instead
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
+          </svg>
+        </a>
+      </div>
+
+      <!-- Empty state -->
+      <div id="blog-empty" class="hidden text-center py-16">
+        <div class="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+          <svg class="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+          </svg>
+        </div>
+        <h3 class="text-xl font-semibold text-gray-700 mb-2">No posts found</h3>
+        <p class="text-gray-500">Try clearing the tag filter.</p>
+      </div>
+
+      <!-- Post grid -->
+      <div id="blog-grid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"></div>
+
+      <!-- Load more -->
+      <div class="flex justify-center mt-10">
+        <button id="load-more" type="button"
+                class="inline-flex items-center gap-2 px-8 py-3 bg-white border border-gray-200 text-gray-700 rounded-xl font-semibold shadow-sm hover:shadow-md hover:border-blue-300 hover:text-blue-600 transition-all duration-300">
+          Load more posts
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+          </svg>
+        </button>
+      </div>
+
+    </div>
+  </main>
+
+  <footer class="text-center py-8 text-sm text-gray-400 border-t border-gray-100 bg-white/60">
+    <p>
+      Words by <a href="index.html" class="text-blue-500 hover:text-blue-600">Sam Rayatnia</a>
+      · Originally published on
+      <a href="https://blog.rayatnia.me" target="_blank" rel="noopener noreferrer"
+         class="text-blue-500 hover:text-blue-600">Medium</a>
+    </p>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js" defer></script>
+  <script src="static/js/blog.js" defer></script>
+</body>
+</html>

--- a/education.html
+++ b/education.html
@@ -13,6 +13,7 @@
     <a href="experience.html" class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Experience</a>
     <a href="education.html" class="font-medium text-blue-600 border-b-2 border-blue-500 pb-1">Education</a>
     <a href="skills.html" class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Skills</a>
+    <a href="blog.html"   class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Blog</a>
   </nav>
   
   <main class="flex-1 py-12 px-4">

--- a/experience.html
+++ b/experience.html
@@ -13,6 +13,7 @@
     <a href="experience.html" class="font-medium text-blue-600 border-b-2 border-blue-500 pb-1">Experience</a>
     <a href="education.html" class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Education</a>
     <a href="skills.html" class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Skills</a>
+    <a href="blog.html"   class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Blog</a>
   </nav>
   
   <main class="flex-1 py-12 px-4">

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <a href="experience.html" class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Experience</a>
     <a href="education.html" class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Education</a>
     <a href="skills.html" class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Skills</a>
+    <a href="blog.html"   class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Blog</a>
   </nav>
   
   <main class="flex-1 py-12 px-4">
@@ -55,7 +56,7 @@
       </div>
 
       <!-- Navigation Cards -->
-      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         <!-- Profile Card -->
         <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 hover:shadow-md transition-all duration-300 hover:-translate-y-1">
           <div class="w-12 h-12 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-lg flex items-center justify-center mb-4">
@@ -124,6 +125,24 @@
             </svg>
           </a>
         </div>
+
+        <!-- Blog Card -->
+        <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 hover:shadow-md transition-all duration-300 hover:-translate-y-1">
+          <div class="w-12 h-12 bg-gradient-to-br from-cyan-500 to-blue-600 rounded-lg flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
+            </svg>
+          </div>
+          <h3 class="text-xl font-bold text-gray-900 mb-2">Blog</h3>
+          <p class="text-gray-600 text-sm mb-4">iOS engineering, software architecture, and computational neuroscience — from my Medium.</p>
+          <a href="blog.html" class="inline-flex items-center text-cyan-600 font-semibold hover:text-cyan-700 transition-colors">
+            Read Posts
+            <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+            </svg>
+          </a>
+        </div>
+
       </div>
     </div>
   </main>

--- a/profile.html
+++ b/profile.html
@@ -13,6 +13,7 @@
     <a href="experience.html" class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Experience</a>
     <a href="education.html" class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Education</a>
     <a href="skills.html" class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Skills</a>
+    <a href="blog.html"   class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Blog</a>
   </nav>
   
   <main class="flex-1 py-12 px-4">

--- a/skills.html
+++ b/skills.html
@@ -13,6 +13,7 @@
     <a href="experience.html" class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Experience</a>
     <a href="education.html" class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Education</a>
     <a href="skills.html" class="font-medium text-blue-600 border-b-2 border-blue-500 pb-1">Skills</a>
+    <a href="blog.html"   class="font-medium text-gray-600 hover:text-blue-600 transition-colors">Blog</a>
   </nav>
   
   <main class="flex-1 py-12 px-4">

--- a/static/js/blog.js
+++ b/static/js/blog.js
@@ -1,0 +1,439 @@
+/* ============================================================
+   blog.js — Medium blog integration for sam.rayatnia.me
+   Fetches feed via rss2json, sanitises with DOMPurify,
+   caches in sessionStorage, runs on both list & post pages.
+   ============================================================ */
+(() => {
+  'use strict';
+
+  // ── Config ─────────────────────────────────────────────────────────────────
+  const MEDIUM_FEED  = 'https://medium.com/feed/@rayatnia';
+  const API_URL      = 'https://api.rss2json.com/v1/api.json?rss_url='
+                     + encodeURIComponent(MEDIUM_FEED) + '&count=20';
+  const CACHE_KEY    = 'blog_feed_v1';
+  const CACHE_TTL    = 15 * 60 * 1000; // 15 minutes
+  const PAGE_SIZE    = 6;
+
+  const GRADIENTS = [
+    ['from-blue-500',    'to-indigo-600'],
+    ['from-indigo-500',  'to-purple-600'],
+    ['from-purple-500',  'to-pink-600'],
+    ['from-pink-500',    'to-rose-600'],
+    ['from-cyan-500',    'to-blue-600'],
+    ['from-emerald-500', 'to-teal-600'],
+  ];
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  function escapeHtml(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function safeHref(url) {
+    try {
+      const u = new URL(url);
+      return (u.protocol === 'https:' || u.protocol === 'http:') ? url : '#';
+    } catch (_) { return '#'; }
+  }
+
+  function readingTime(html) {
+    const words = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim().split(' ').length;
+    return Math.max(1, Math.ceil(words / 200));
+  }
+
+  function formatDate(str) {
+    return new Date(str).toLocaleDateString('en-US', {
+      year: 'numeric', month: 'long', day: 'numeric',
+    });
+  }
+
+  function extractThumb(content) {
+    const m = content.match(/<img[^>]+src="([^"]+)"/);
+    return m ? m[1] : null;
+  }
+
+  function plainExcerpt(html, max = 160) {
+    const txt = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+    return txt.length > max ? txt.slice(0, max - 1) + '\u2026' : txt;
+  }
+
+  function sanitize(html) {
+    if (typeof DOMPurify === 'undefined') return '';
+    return DOMPurify.sanitize(html, {
+      USE_PROFILES: { html: true },
+      FORBID_TAGS:  ['script', 'style', 'iframe', 'form', 'input', 'object', 'embed'],
+      FORBID_ATTR:  ['onerror', 'onload', 'onclick', 'onmouseover', 'onfocus',
+                     'onblur', 'onchange', 'onsubmit'],
+    });
+  }
+
+  // ── Feed fetch with cache ───────────────────────────────────────────────────
+
+  async function fetchFeed() {
+    try {
+      const raw = sessionStorage.getItem(CACHE_KEY);
+      if (raw) {
+        const { data, ts } = JSON.parse(raw);
+        if (Date.now() - ts < CACHE_TTL) return data;
+      }
+    } catch (_) { /* ignore corrupt cache */ }
+
+    const res = await fetch(API_URL);
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    const json = await res.json();
+    if (json.status !== 'ok') throw new Error('Feed: ' + (json.message || 'unknown error'));
+
+    try {
+      sessionStorage.setItem(CACHE_KEY, JSON.stringify({ data: json, ts: Date.now() }));
+    } catch (_) { /* ignore quota errors */ }
+
+    return json;
+  }
+
+  // ── Skeleton card ──────────────────────────────────────────────────────────
+
+  function buildSkeleton() {
+    const el = document.createElement('div');
+    el.className = 'bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden animate-pulse';
+    el.innerHTML = `
+      <div class="h-48 bg-gray-200"></div>
+      <div class="p-6 space-y-3">
+        <div class="h-4 bg-gray-200 rounded-lg w-3/4"></div>
+        <div class="h-4 bg-gray-200 rounded-lg w-1/2"></div>
+        <div class="h-3 bg-gray-200 rounded-lg w-full mt-4"></div>
+        <div class="h-3 bg-gray-200 rounded-lg w-5/6"></div>
+        <div class="h-3 bg-gray-200 rounded-lg w-4/6"></div>
+        <div class="flex justify-between pt-3 border-t border-gray-100 mt-2">
+          <div class="h-3 bg-gray-200 rounded w-24"></div>
+          <div class="h-3 bg-gray-200 rounded w-16"></div>
+        </div>
+      </div>`;
+    return el;
+  }
+
+  // ── Post card ──────────────────────────────────────────────────────────────
+
+  function buildCard(post, idx) {
+    const thumb   = extractThumb(post.content);
+    const excerpt = plainExcerpt(post.description || post.content);
+    const mins    = readingTime(post.content);
+    const date    = formatDate(post.pubDate);
+    const [gFrom, gTo] = GRADIENTS[idx % GRADIENTS.length];
+    const href    = 'blog-post.html?link=' + encodeURIComponent(post.link);
+    const tags    = (post.categories || []).slice(0, 3);
+
+    const card = document.createElement('a');
+    card.href      = href;
+    card.className = 'group bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden '
+                   + 'hover:shadow-lg transition-all duration-300 hover:-translate-y-1 flex flex-col';
+
+    // ── Thumbnail ──
+    const thumbDiv = document.createElement('div');
+    thumbDiv.className = `relative h-48 bg-gradient-to-br ${gFrom} ${gTo} overflow-hidden flex-shrink-0`;
+
+    if (thumb) {
+      const img = document.createElement('img');
+      img.src     = thumb;
+      img.alt     = post.title;
+      img.loading = 'lazy';
+      img.className = 'w-full h-full object-cover group-hover:scale-105 transition-transform duration-500';
+      img.addEventListener('error', () => img.remove());
+      thumbDiv.appendChild(img);
+    }
+
+    if (tags.length) {
+      const tagsDiv = document.createElement('div');
+      tagsDiv.className = 'absolute bottom-3 left-3 flex flex-wrap gap-1';
+      tags.forEach(tag => {
+        const span = document.createElement('span');
+        span.className   = 'px-2 py-0.5 bg-white/20 backdrop-blur-sm text-white text-xs rounded-full font-medium capitalize';
+        span.textContent = tag.replace(/-/g, ' ');
+        tagsDiv.appendChild(span);
+      });
+      thumbDiv.appendChild(tagsDiv);
+    }
+
+    card.appendChild(thumbDiv);
+
+    // ── Body ──
+    const body = document.createElement('div');
+    body.className = 'p-6 flex flex-col flex-1';
+
+    const title = document.createElement('h3');
+    title.className   = 'text-lg font-bold text-gray-900 mb-2 line-clamp-2 group-hover:text-blue-600 transition-colors';
+    title.textContent = post.title;
+    body.appendChild(title);
+
+    const exc = document.createElement('p');
+    exc.className   = 'text-gray-500 text-sm leading-relaxed mb-4 line-clamp-3 flex-1';
+    exc.textContent = excerpt;
+    body.appendChild(exc);
+
+    const meta = document.createElement('div');
+    meta.className = 'flex items-center justify-between text-xs text-gray-400 pt-3 border-t border-gray-100';
+    const dateSpan = document.createElement('span');
+    dateSpan.textContent = date;
+    const minsSpan = document.createElement('span');
+    minsSpan.textContent = mins + ' min read';
+    meta.appendChild(dateSpan);
+    meta.appendChild(minsSpan);
+    body.appendChild(meta);
+
+    card.appendChild(body);
+    return card;
+  }
+
+  // ── Tag pill ───────────────────────────────────────────────────────────────
+
+  function buildTagPill(label, tag, active) {
+    const btn = document.createElement('button');
+    btn.type         = 'button';
+    btn.dataset.tag  = tag;
+    btn.textContent  = label;
+    btn.className    = 'px-3 py-1 rounded-full text-sm font-medium transition-colors whitespace-nowrap capitalize '
+                     + (active
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-gray-100 text-gray-600 hover:bg-blue-100 hover:text-blue-700');
+    return btn;
+  }
+
+  // ── Blog list page ─────────────────────────────────────────────────────────
+
+  async function initList() {
+    const grid        = document.getElementById('blog-grid');
+    const loadMoreBtn = document.getElementById('load-more');
+    const errorDiv    = document.getElementById('blog-error');
+    const emptyDiv    = document.getElementById('blog-empty');
+    const tagBar      = document.getElementById('tag-bar');
+    const countEl     = document.getElementById('post-count');
+
+    if (!grid) return;
+
+    let allPosts = [], filtered = [], shown = 0;
+
+    // Show skeletons
+    for (let i = 0; i < PAGE_SIZE; i++) grid.appendChild(buildSkeleton());
+
+    function updateCount() {
+      if (countEl) countEl.textContent = shown + ' of ' + filtered.length + ' posts';
+    }
+
+    function renderBatch() {
+      const batch = filtered.slice(shown, shown + PAGE_SIZE);
+      batch.forEach((post, i) => grid.appendChild(buildCard(post, shown + i)));
+      shown += batch.length;
+      updateCount();
+      if (shown >= filtered.length) loadMoreBtn.classList.add('hidden');
+      else loadMoreBtn.classList.remove('hidden');
+    }
+
+    function applyFilter(tag) {
+      filtered = tag ? allPosts.filter(p => (p.categories || []).includes(tag)) : allPosts;
+      shown    = 0;
+      grid.innerHTML = '';
+
+      // Update pill states
+      document.querySelectorAll('[data-tag]').forEach(el => {
+        const active = el.dataset.tag === (tag || '');
+        el.className = el.className
+          .replace(/bg-blue-600|text-white|bg-gray-100|text-gray-600/g, '').trim()
+          + ' ' + (active
+            ? 'bg-blue-600 text-white'
+            : 'bg-gray-100 text-gray-600 hover:bg-blue-100 hover:text-blue-700');
+      });
+
+      if (filtered.length === 0) {
+        emptyDiv && emptyDiv.classList.remove('hidden');
+        loadMoreBtn.classList.add('hidden');
+        updateCount();
+        return;
+      }
+      emptyDiv && emptyDiv.classList.add('hidden');
+      renderBatch();
+    }
+
+    try {
+      const feed = await fetchFeed();
+      allPosts = feed.items || [];
+      grid.innerHTML = '';
+
+      if (allPosts.length === 0) {
+        emptyDiv && emptyDiv.classList.remove('hidden');
+        loadMoreBtn.classList.add('hidden');
+        return;
+      }
+
+      // Build tag pills
+      if (tagBar) {
+        const allTags = [...new Set(allPosts.flatMap(p => p.categories || []))]
+          .filter(Boolean).sort();
+
+        tagBar.appendChild(buildTagPill('All', '', true));
+        allTags.forEach(t => tagBar.appendChild(buildTagPill(t.replace(/-/g, ' '), t, false)));
+
+        tagBar.addEventListener('click', e => {
+          const btn = e.target.closest('[data-tag]');
+          if (!btn) return;
+          applyFilter(btn.dataset.tag || null);
+        });
+      }
+
+      filtered = allPosts;
+      renderBatch();
+      loadMoreBtn.addEventListener('click', renderBatch);
+
+    } catch (err) {
+      grid.innerHTML = '';
+      errorDiv && errorDiv.classList.remove('hidden');
+      loadMoreBtn.classList.add('hidden');
+      console.error('[Blog]', err);
+    }
+  }
+
+  // ── Blog post page ─────────────────────────────────────────────────────────
+
+  async function initPost() {
+    const container = document.getElementById('post-container');
+    if (!container) return;
+
+    const loadingEl = document.getElementById('post-loading');
+    const errorEl   = document.getElementById('post-error');
+    const params    = new URLSearchParams(location.search);
+    const postLink  = params.get('link');
+
+    if (!postLink) { location.href = 'blog.html'; return; }
+
+    try {
+      const feed = await fetchFeed();
+      const post = (feed.items || []).find(p => p.link === postLink);
+      if (!post) throw new Error('Post not found');
+
+      loadingEl && loadingEl.classList.add('hidden');
+      document.title = post.title + ' | Sam Rayatnia';
+      renderPost(post, container);
+
+    } catch (err) {
+      loadingEl && loadingEl.classList.add('hidden');
+      errorEl  && errorEl.classList.remove('hidden');
+      console.error('[Blog]', err);
+    }
+  }
+
+  function renderPost(post, container) {
+    const mins        = readingTime(post.content);
+    const date        = formatDate(post.pubDate);
+    const tags        = post.categories || [];
+    const safeContent = sanitize(post.content);
+    const mediumHref  = safeHref(post.link);
+
+    // Header
+    const header = document.createElement('div');
+    header.className = 'mb-8';
+
+    // Tags
+    if (tags.length) {
+      const tagRow = document.createElement('div');
+      tagRow.className = 'flex flex-wrap gap-2 mb-4';
+      tags.forEach(t => {
+        const span = document.createElement('span');
+        span.className   = 'px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-sm font-medium capitalize';
+        span.textContent = t.replace(/-/g, ' ');
+        tagRow.appendChild(span);
+      });
+      header.appendChild(tagRow);
+    }
+
+    // Title
+    const h1 = document.createElement('h1');
+    h1.className   = 'text-3xl sm:text-4xl font-bold text-gray-900 mb-5 leading-tight';
+    h1.textContent = post.title;
+    header.appendChild(h1);
+
+    // Meta row
+    const meta = document.createElement('div');
+    meta.className = 'flex flex-wrap items-center gap-3 text-sm text-gray-500 mb-8';
+
+    const dateEl = document.createElement('span');
+    dateEl.textContent = date;
+    meta.appendChild(dateEl);
+
+    meta.insertAdjacentHTML('beforeend', '<span class="text-gray-300">·</span>');
+
+    const minsEl = document.createElement('span');
+    minsEl.textContent = mins + ' min read';
+    meta.appendChild(minsEl);
+
+    meta.insertAdjacentHTML('beforeend', '<span class="text-gray-300">·</span>');
+
+    const extLink = document.createElement('a');
+    extLink.href      = mediumHref;
+    extLink.target    = '_blank';
+    extLink.rel       = 'noopener noreferrer';
+    extLink.className = 'inline-flex items-center gap-1 text-blue-600 hover:text-blue-700 font-medium';
+    extLink.innerHTML = 'Read on Medium <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">'
+                      + '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" '
+                      + 'd="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>';
+    meta.appendChild(extLink);
+
+    header.appendChild(meta);
+
+    // Divider
+    const divider = document.createElement('div');
+    divider.className = 'w-24 h-1 bg-gradient-to-r from-blue-500 to-indigo-500 rounded-full';
+    header.appendChild(divider);
+
+    container.appendChild(header);
+
+    // Article content
+    const article = document.createElement('div');
+    article.className = 'prose-content';
+    article.innerHTML = safeContent;
+
+    // Make all links in article open in new tab safely
+    article.querySelectorAll('a').forEach(a => {
+      a.target = '_blank';
+      a.rel    = 'noopener noreferrer';
+    });
+    // Lazy-load images in article
+    article.querySelectorAll('img').forEach(img => {
+      img.loading = 'lazy';
+      img.style.maxWidth = '100%';
+    });
+
+    container.appendChild(article);
+
+    // Footer CTA
+    const cta = document.createElement('div');
+    cta.className = 'mt-12 pt-8 border-t border-gray-100 flex flex-col sm:flex-row gap-4 items-start sm:items-center';
+    cta.innerHTML = `
+      <a href="${escapeHtml(mediumHref)}" target="_blank" rel="noopener noreferrer"
+         class="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-blue-500 to-indigo-600 text-white rounded-xl font-semibold hover:shadow-lg transition-all duration-300 hover:-translate-y-0.5">
+        Continue reading on Medium
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
+        </svg>
+      </a>
+      <a href="blog.html"
+         class="inline-flex items-center gap-2 text-gray-600 hover:text-blue-600 font-medium transition-colors">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+        </svg>
+        Back to all posts
+      </a>`;
+    container.appendChild(cta);
+  }
+
+  // ── Bootstrap ──────────────────────────────────────────────────────────────
+
+  document.addEventListener('DOMContentLoaded', () => {
+    if (document.getElementById('blog-grid'))      initList();
+    if (document.getElementById('post-container')) initPost();
+  });
+
+})();


### PR DESCRIPTION
## Summary

- **`blog.html`** — Blog list page with 3-col responsive grid, skeleton loading, tag filter pills, post count, load more, error and empty states
- **`blog-post.html`** — Article detail page with full prose styles (headings, code, blockquotes, tables, images), reading time, tags, and "Read on Medium" CTA
- **`static/js/blog.js`** — Fetches `medium.com/feed/@rayatnia` via rss2json, 15-min sessionStorage cache, full HTML sanitisation with DOMPurify 3, URL-param routing
- **All pages** — "Blog" nav link added to every page
- **`index.html`** — Blog card added to home navigation grid

## Security

- All article HTML sanitised with [DOMPurify](https://github.com/cure53/DOMPurify) — scripts, iframes, and event-handler attributes stripped
- URLs validated via `new URL()` before insertion into `href`
- `escapeHtml()` applied to all plain strings used in `innerHTML` context
- External links get `rel="noopener noreferrer"`

## Test plan

- [ ] `blog.html` loads and shows skeleton cards, then renders posts
- [ ] Tag pills filter correctly; "All" resets the view
- [ ] "Load more" appends the next batch and hides when exhausted
- [ ] Clicking a card opens `blog-post.html` with the correct article
- [ ] Article content renders with prose styles (headings, code blocks, images)
- [ ] Error state shows if the feed fails to load
- [ ] "Blog" nav link is active on blog pages, inactive on all others

🤖 Generated with [Claude Code](https://claude.com/claude-code)